### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Publish Status](https://github.com/ether/ep_dynamic_default_content/workflows/Node.js%20Package/badge.svg) [![Backend Tests Status](https://github.com/ether/ep_dynamic_default_content/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_dynamic_default_content/actions/workflows/test-and-release.yml)
 
-# ep_dynamic_default_content
+# Dynamic Default Content for Etherpad
 
 Etherpad plugin to dynamically generate a pad's initial content.
 


### PR DESCRIPTION
Replace the placeholder `ep_dynamic_default_content` heading in README.md with "Dynamic Default Content for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.