### PR TITLE
ci: pin pnpm to 10.33.0 via packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,6 @@
   "funding": {
     "type": "individual",
     "url": "https://etherpad.org/"
-  }
+  },
+  "packageManager": "pnpm@10.33.0"
 }


### PR DESCRIPTION
Fixes `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` in the publish workflow. Root cause: `pnpm/action-setup@v6` installs pnpm 11.0.0-beta regardless of `version: 10` input (pnpm/action-setup#225). pnpm 11 normalises `overrides` differently from pnpm 10 so it rejects the lockfile. Pin pnpm via `packageManager` so CI uses the same version that wrote the lockfile.