### PR TITLE
ci: install Node 22 + trigger release after Dependabot Automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,6 +2,12 @@ name: Dependabot Automerge
 permissions:
   contents: write
   pull-requests: write
+  # `actions: write` lets the post-merge step kick off Node.js Package on
+  # the default branch via `gh workflow run`. Without this, automerge'd
+  # PRs land on main but the on-push release job never fires (GitHub
+  # Actions intentionally suppresses on:push triggers when the push is
+  # authenticated with GITHUB_TOKEN).
+  actions: write
 on:
   workflow_run:
     workflows:
@@ -21,6 +27,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Automerge
+        id: automerge
         uses: "pascalgn/automerge-action@v0.16.4"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -28,3 +35,11 @@ jobs:
           MERGE_LABELS: ""
           MERGE_RETRY_SLEEP: "100000"
 
+      - name: Trigger release on default branch
+        # `pascalgn/automerge-action` exits 0 whether or not it merged. Skip
+        # the dispatch when nothing was actually merged so we don't kick a
+        # phantom release run on every Dependabot Automerge invocation.
+        if: steps.automerge.outputs.mergeResult == 'merged'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run test-and-release.yml --ref ${{ github.event.repository.default_branch }}

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           repository: ether/etherpad-lite
           path: etherpad-lite
+      - uses: actions/setup-node@v4
+        name: Install Node.js
+        with:
+          node-version: 22
       - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -15,6 +15,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ether/etherpad-lite
+      - uses: actions/setup-node@v4
+        name: Install Node.js
+        with:
+          node-version: 22
       - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -1,5 +1,11 @@
 name: Node.js Package
-on: [push]
+on:
+  push:
+  # Invoked by automerge.yml after a Dependabot PR is merged. GitHub
+  # Actions doesn't fire on:push when the push is authored by GITHUB_TOKEN
+  # (the automerge action's only available identity), so without this
+  # dispatch trigger the release job never runs after auto-merges.
+  workflow_dispatch:
 
 # id-token: write must be granted here so the reusable npmpublish workflow
 # can request an OIDC token for npm trusted publishing.


### PR DESCRIPTION
## Summary

Two unrelated CI bugs that were blocking the same `test-and-release.yml` job graph:

1. **Node 22 in backend + frontend test jobs.** Both workflows were running on the runner image's default Node (20.20), but Etherpad core's `bin/installDeps.sh` requires Node 22+ — last main run fails with:
   > ERROR: Your nodejs version \"20.20\" is too old. nodejs 22.0.x or higher is required.

   Add `actions/setup-node@v4` with `node-version: 22` to both jobs.

2. **Auto-publish after Dependabot merges.** GitHub suppresses `on:push` triggers when the push is authored by `GITHUB_TOKEN` (the automerge-action's only available identity), so merged Dependabot PRs landed on main without ever firing the release job. Fix mirrors what's shipped across the rest of the ether/* plugins:
   - `automerge.yml` gets `actions: write` and a post-merge `gh workflow run test-and-release.yml --ref <default branch>` step, gated on `mergeResult == 'merged'`.
   - `test-and-release.yml` gains a `workflow_dispatch:` trigger so `gh workflow run` is permitted.

A previous attempt at #2 (branch `fix/automerge-trigger-release`, run 25259365984) failed because Node 22 wasn't installed yet — bundling both fixes here unblocks both.

## Test plan

- [ ] Backend Tests succeed on this branch
- [ ] Frontend Tests succeed on this branch
- [ ] After merge, the next Dependabot auto-merge triggers a release run