### PR TITLE
ci: pin workflows to Node 25

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-node@v6
         name: Install Node.js
         with:
-          node-version: '>=22'
+          node-version: 25
       - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-node@v6
         name: Install Node.js
         with:
-          node-version: '>=22'
+          node-version: 25
       - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -23,7 +23,7 @@ jobs:
           # OIDC trusted publishing needs npm >= 11.5.1, which requires
           # Node >= 20.17.0. setup-node's `20` resolves to the latest
           # 20.x, which satisfies that.
-          node-version: '>=22'
+          node-version: 25
           registry-url: https://registry.npmjs.org/
       - name: Upgrade npm to >=11.5.1 (required for trusted publishing)
         run: npm install -g npm@latest


### PR DESCRIPTION
Follow-up to the earlier workflow runtime rollout: `actions/setup-node` resolved `>=22` to newer majors, so pin the workflows to Node 25 instead.